### PR TITLE
update dhall

### DIFF
--- a/dhall-bash-simple.nix
+++ b/dhall-bash-simple.nix
@@ -5,12 +5,12 @@ pkgs.stdenv.mkDerivation rec {
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.0/dhall-bash-1.0.23-x86_64-macos.tar.bz2";
-    sha256 = "1v941mad72xww4zyz4kr1d6czyl8834pbfrqpafnixj4brs6vzy5";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-bash-1.0.23-x86_64-macos.tar.bz2";
+    sha256 = "1gbz8li37vs2lnwdsf097kgij6d0z14fgwncdrs22915j44hiqrd";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.0/dhall-bash-1.0.23-x86_64-linux.tar.bz2";
-    sha256 = "1viq504bg5s9as984f93isakhzrb4nxg43s9y63jfhb17xf9rb3b";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-bash-1.0.23-x86_64-linux.tar.bz2";
+    sha256 = "0ksycmd3b9h3i5q8y0a8yhpbpkzyrfazm7j2cx4ngdszlq586kna";
   };
 
   installPhase = ''

--- a/dhall-json-simple.nix
+++ b/dhall-json-simple.nix
@@ -5,12 +5,12 @@ pkgs.stdenv.mkDerivation rec {
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.0/dhall-json-1.4.1-x86_64-macos.tar.bz2";
-    sha256 = "1m5cw6b9xhr9qi55ih3dvkj7vzmh9jpswfqdadmw4r6rgsia8jg1";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-json-1.4.1-x86_64-macos.tar.bz2";
+    sha256 = "147cbc5fw6iaynmyz4iz5r9bmq7kldhjvzj6pa4l10i4asal7da1";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.0/dhall-json-1.4.1-x86_64-linux.tar.bz2";
-    sha256 = "0hv5x8ps0z74acsh91ivlg5vw7r0c8p0g92ca1mxm7m4p4vf936k";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-json-1.4.1-x86_64-linux.tar.bz2";
+    sha256 = "1hpd3rwpawwgpb5v2ib5hnsl1jbw4p109hhd6qhi2fc8rd7g5s89";
   };
 
   installPhase = ''

--- a/dhall-nix-simple.nix
+++ b/dhall-nix-simple.nix
@@ -4,10 +4,13 @@ pkgs.stdenv.mkDerivation rec {
   name = "dhall-nix-simple";
 
   src = if pkgs.stdenv.isDarwin
-  then throw "dhall nix only released for linux"
+  then pkgs.fetchurl {
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-nix-1.1.8-x86_64-macos.tar.bz2";
+    sha256 = "0dgg5iljf8crx5vas8v5lz79h5kk4ss6vg1ngavs32vshzs9q9kc";
+  }
   else pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.0/dhall-nix-1.1.8-x86_64-linux.tar.bz2";
-    sha256 = "0zb1fl5bzaqfjg95m4znw3dcjkndl0nk6c70qd9pbrb4d2xch6s8";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-nix-1.1.8-x86_64-linux.tar.bz2";
+    sha256 = "1mqkk598xx4hbpq9az9biwzc4gwmxb98wjm2ss0agvpdr75w5xm4";
   };
 
   installPhase = ''

--- a/dhall-simple.nix
+++ b/dhall-simple.nix
@@ -5,12 +5,12 @@ pkgs.stdenv.mkDerivation rec {
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.0/dhall-1.26.0-x86_64-macos.tar.bz2";
-    sha256 = "0jy9bwgywqwb7nk1qhpqhi56g7fsk8vhzybwxb8h07qcm47wa6vw";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-1.26.1-x86_64-macos.tar.bz2";
+    sha256 = "1mdgjcwpar53h8dmhq4x3n7s6idinzxyim6g2z1d7r7dwjqmmll6";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.0/dhall-1.26.0-x86_64-linux.tar.bz2";
-    sha256 = "0q6zdkf1grzj1hblx1ngdfss41bisl7a3fz9xl9zz229s7n5grq5";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.26.1/dhall-1.26.1-x86_64-linux.tar.bz2";
+    sha256 = "0sl4r3mfairgd6kn26hs1r1lkh8rn992grd73078rhqf5w90ag05";
   };
 
   installPhase = ''

--- a/shell.nix
+++ b/shell.nix
@@ -1,17 +1,16 @@
 let
   pkgs = import ./nixpkgs.nix {};
-  default = import ./default.nix { inherit pkgs; };
+
+  default = import ./default.nix {
+    inherit pkgs;
+  };
 
 in
-  with default;
-  pkgs.mkShell {
+  with default; pkgs.mkShell {
     buildInputs = [
       dhall-simple
       dhall-json-simple
       dhall-bash-simple
-    ] ++ (
-      if pkgs.stdenv.isDarwin then [] else [
-        dhall-nix-simple
-      ]
-    );
+      dhall-nix-simple
+    ];
   }

--- a/test.bash
+++ b/test.bash
@@ -17,10 +17,6 @@ function test_exe () {
 test_exe dhall;
 test_exe dhall-to-json;
 test_exe dhall-to-bash;
-
-if [[ "$OSTYPE" != "darwin"* ]]
-then
-  test_exe dhall-to-nix;
-fi
+test_exe dhall-to-nix;
 
 exit $ERRORS;


### PR DESCRIPTION
removes some osx workarounds too since dhall-nix is now correctly included in the releases