### PR TITLE
Update to 1.30

### DIFF
--- a/dhall-bash-simple.nix
+++ b/dhall-bash-simple.nix
@@ -5,12 +5,12 @@ pkgs.stdenv.mkDerivation rec {
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-bash-1.0.27-x86_64-macos.tar.bz2";
-    sha256 = "1zi37x1ifl0qxd7lby72snkf5mmg1xaclm7v815grdvjs08dg4vb";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-bash-1.0.28-x86_64-macos.tar.bz2";
+    sha256 = "1flzfjb9qxphpgzpp9acpgxdylkn97zbrw6f3lbz6rnb2k7sc8b5";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-bash-1.0.27-x86_64-linux.tar.bz2";
-    sha256 = "0rbj42dgsms7074zqsnf6fs0l000mw4ah87ng9411ysaaf3fn35b";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-bash-1.0.28-x86_64-linux.tar.bz2";
+    sha256 = "0v377zbna1m7mphgzmibbs35k3bshx22iwvnyciwryl9x2hglbsg";
   };
 
   installPhase = ''

--- a/dhall-json-simple.nix
+++ b/dhall-json-simple.nix
@@ -5,12 +5,12 @@ pkgs.stdenv.mkDerivation rec {
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-json-1.6.1-x86_64-macos.tar.bz2";
-    sha256 = "1v4h36f0s57w9k7sd4p2xngvds9lsxfsmcx7jnqmgybw8zzvm5sq";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-json-1.6.2-x86_64-macos.tar.bz2";
+    sha256 = "02j0lg285a1a7w4rxcmvvn3fxyn5mnxrrgzdn8j4yjdbizkq13lx";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-json-1.6.1-x86_64-linux.tar.bz2";
-    sha256 = "142jn8vaw8zf8qsmz1k23g0x9665i137gg13ip8jjmi1zcrzjrby";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-json-1.6.2-x86_64-linux.tar.bz2";
+    sha256 = "1wzlxcfvw1nf6g5rhnsd7g079f25n569s2gg7prrly0r9ry64dza";
   };
 
   installPhase = ''

--- a/dhall-nix-simple.nix
+++ b/dhall-nix-simple.nix
@@ -5,12 +5,12 @@ pkgs.stdenv.mkDerivation rec {
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-nix-1.1.11-x86_64-macos.tar.bz2";
-    sha256 = "0vrzsq09v1132sb2v7p4iidydbc64vrap6zlaa8v5j75gl98nbm7";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-nix-1.1.12-x86_64-macos.tar.bz2";
+    sha256 = "19fyhwldla827im6xajhdwgfcim66r9ajc6rwyhl18qlhfbddqhm";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-nix-1.1.11-x86_64-linux.tar.bz2";
-    sha256 = "0p5k3ij9cssywbsyhpyn7y2nz7fry0lmdi7j2dd516jm6kikbvh4";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-nix-1.1.12-x86_64-linux.tar.bz2";
+    sha256 = "0wskg94n64khx3advc019bxmfa67pzvjkd1q2fjpz8cnn9953gmf";
   };
 
   installPhase = ''

--- a/dhall-simple.nix
+++ b/dhall-simple.nix
@@ -5,12 +5,12 @@ pkgs.stdenv.mkDerivation rec {
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-1.29.0-x86_64-macos.tar.bz2";
-    sha256 = "0liqfhvwbpjykrcd547f6814zzgc4rhilfk42jr0h24557ivcfj6";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-1.30.0-x86_64-macos.tar.bz2";
+    sha256 = "03s4fj7i3jvnjk3faiqd77g46xxyj85i10jxrv2nvgy14kmx11cr";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-1.29.0-x86_64-linux.tar.bz2";
-    sha256 = "1lamg0vli5r9lshxg40nysirvn264hk3w9zk7hcar6lihcxdnwz2";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-1.30.0-x86_64-linux.tar.bz2";
+    sha256 = "00llrslfvlihfzryfvh8z2dz93nz1327h4ha2ks41k63x4fl4ib8";
   };
 
   installPhase = ''

--- a/dhall-yaml-simple.nix
+++ b/dhall-yaml-simple.nix
@@ -5,12 +5,12 @@ pkgs.stdenv.mkDerivation rec {
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-yaml-1.0.1-x86_64-macos.tar.bz2";
-    sha256 = "0rg1gsr6fhx71sadr8xcwik202jfbpwcvgj3bjzbvsx8hvn2cy13";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-yaml-1.0.2-x86_64-macos.tar.bz2";
+    sha256 = "05hj7h682bwk721r86qjq4s24q1vy302kacak9gn7l6k05awx166";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-yaml-1.0.1-x86_64-linux.tar.bz2";
-    sha256 = "13gnqq3xjilrs4zmp7c7jybyw9xa7ipi3kkrp7mr826vypcwlrga";
+    url = "https://github.com/dhall-lang/dhall-haskell/releases/download/1.30.0/dhall-yaml-1.0.2-x86_64-linux.tar.bz2";
+    sha256 = "0n8015gc7pkqppqabxw66yvdv0kzd747z3hr477bzv1aawpc8i9f";
   };
 
   installPhase = ''


### PR DESCRIPTION
Once again, MacOS wasn't tested, only Linux. Hashes updated using `nix-prefetch-url`, so at last that should be okay.