### PR TITLE
dhall-json-simple: add json-to-dhall and dhall-yaml

### DIFF
--- a/dhall-json-simple.nix
+++ b/dhall-json-simple.nix
@@ -20,9 +20,15 @@ pkgs.stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     DHALL_TO_JSON=$out/bin/dhall-to-json
+    DHALL_TO_YAML=$out/bin/dhall-to-yaml
+    JSON_TO_DHALL=$out/bin/json-to-dhall
     install -D -m555 -T dhall-to-json $DHALL_TO_JSON
+    install -D -m555 -T dhall-to-yaml $DHALL_TO_YAML
+    install -D -m555 -T json-to-dhall $JSON_TO_DHALL
 
     mkdir -p $out/etc/bash_completion.d/
     $DHALL_TO_JSON --bash-completion-script $DHALL_TO_JSON > $out/etc/bash_completion.d/dhall-to-json-completion.bash
+    $DHALL_TO_YAML --bash-completion-script $DHALL_TO_YAML > $out/etc/bash_completion.d/dhall-to-yaml-completion.bash
+    $JSON_TO_DHALL --bash-completion-script $JSON_TO_DHALL > $out/etc/bash_completion.d/json-to-dhall-completion.bash
   '';
 }


### PR DESCRIPTION
There’s more stuff now. Maybe we should have a check that we don’t
miss when they add binaries?