### PR TITLE
Refactor build.nix

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -1,0 +1,30 @@
+{ pkgs, release }:
+
+{ simpleName, binName, attrName, completionName ? binName }:
+
+let
+  release = import ./release.nix;
+in
+
+pkgs.stdenv.mkDerivation rec {
+  name = simpleName;
+
+  src = if pkgs.stdenv.isDarwin
+  then pkgs.fetchzip {
+    url = release.${"${attrName}-darwin"}.url;
+    sha256 = release.${"${attrName}-darwin"}.hash;
+  }
+  else pkgs.fetchzip {
+    url = release.${"${attrName}-linux"}.url;
+    sha256 = release.${"${attrName}-linux"}.hash;
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    binPath="$out/bin/${binName}"
+    install -D -m555 -T ${binName} "$binPath"
+
+    mkdir -p $out/etc/bash_completion.d/
+    "$binPath" --bash-completion-script "$binPath" > "$out/etc/bash_completion.d/${completionName}-completion.bash"
+  '';
+}

--- a/build.nix
+++ b/build.nix
@@ -1,6 +1,6 @@
 { pkgs, release }:
 
-{ simpleName, binName, attrName, completionName ? binName }:
+{ simpleName, binName, attrName }:
 
 let
   release = import ./release.nix;
@@ -25,6 +25,6 @@ pkgs.stdenv.mkDerivation rec {
     install -D -m555 -T ${binName} "$binPath"
 
     mkdir -p $out/etc/bash_completion.d/
-    "$binPath" --bash-completion-script "$binPath" > "$out/etc/bash_completion.d/${completionName}-completion.bash"
+    "$binPath" --bash-completion-script "$binPath" > "$out/etc/bash_completion.d/${binName}-completion.bash"
   '';
 }

--- a/dhall-bash-simple.nix
+++ b/dhall-bash-simple.nix
@@ -1,28 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-bash-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-bash-darwin.url;
-    sha256 = release.dhall-bash-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-bash-linux.url;
-    sha256 = release.dhall-bash-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL_TO_BASH=$out/bin/dhall-to-bash
-    install -D -m555 -T dhall-to-bash $DHALL_TO_BASH
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL_TO_BASH --bash-completion-script $DHALL_TO_BASH > $out/etc/bash_completion.d/dhall-to-bash-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-bash-simple";
+  binName = "dhall-to-bash";
+  attrName = "dhall-bash";
 }

--- a/dhall-lsp-simple.nix
+++ b/dhall-lsp-simple.nix
@@ -1,28 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-lsp-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-lsp-server-darwin.url;
-    sha256 = release.dhall-lsp-server-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-lsp-server-linux.url;
-    sha256 = release.dhall-lsp-server-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL_LSP=$out/bin/dhall-lsp-server
-    install -D -m555 -T dhall-lsp-server $DHALL_LSP
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL_LSP --bash-completion-script $DHALL_LSP > $out/etc/bash_completion.d/dhall-lsp-server-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-lsp-simple";
+  binName = "dhall-lsp-server";
+  attrName = "dhall-lsp-server";
 }

--- a/dhall-nix-simple.nix
+++ b/dhall-nix-simple.nix
@@ -1,28 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-nix-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-nix-darwin.url;
-    sha256 = release.dhall-nix-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-nix-linux.url;
-    sha256 = release.dhall-nix-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL_TO_NIX=$out/bin/dhall-to-nix
-    install -D -m555 -T dhall-to-nix $DHALL_TO_NIX
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL_TO_NIX --bash-completion-script $DHALL_TO_NIX > $out/etc/bash_completion.d/dhall-to-nix-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-nix-simple";
+  binName = "dhall-to-nix";
+  attrName = "dhall-nix";
 }

--- a/dhall-simple.nix
+++ b/dhall-simple.nix
@@ -1,28 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-darwin.url;
-    sha256 = release.dhall-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-linux.url;
-    sha256 = release.dhall-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL=$out/bin/dhall
-    install -D -m555 -T dhall $DHALL
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL --bash-completion-script $DHALL > $out/etc/bash_completion.d/dhall-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-simple";
+  binName = "dhall";
+  attrName = "dhall";
 }

--- a/dhall-yaml-simple.nix
+++ b/dhall-yaml-simple.nix
@@ -4,5 +4,4 @@ import ./build.nix { inherit pkgs; release = import ./release.nix; } {
   simpleName = "dhall-yaml-simple";
   binName = "dhall-to-yaml-ng";
   attrName = "dhall-yaml";
-  completionName = "dhall-to-yaml";
 }

--- a/dhall-yaml-simple.nix
+++ b/dhall-yaml-simple.nix
@@ -1,28 +1,8 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-yaml-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-yaml-darwin.url;
-    sha256 = release.dhall-yaml-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-yaml-linux.url;
-    sha256 = release.dhall-yaml-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL_TO_YAML=$out/bin/dhall-to-yaml-ng
-    install -D -m555 -T dhall-to-yaml-ng $DHALL_TO_YAML
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL_TO_YAML --bash-completion-script $DHALL_TO_YAML > $out/etc/bash_completion.d/dhall-to-yaml-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-yaml-simple";
+  binName = "dhall-to-yaml-ng";
+  attrName = "dhall-yaml";
+  completionName = "dhall-to-yaml";
 }


### PR DESCRIPTION
The files are very self-similar, and provided upstream doesn’t do
something completely crazy, they should stay that way.

dhall-json is more complicated, and it wasn’t worth it implemented
something more complicated in build.nix, so for now it stays the same.

Also fixes a bug that I found in the process.