### PR TITLE
Add zsh and fish completions

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -1,0 +1,30 @@
+{ pkgs, release }:
+
+{ simpleName, binName, attrName, completionName ? binName }:
+
+let
+  release = import ./release.nix;
+in
+
+pkgs.stdenv.mkDerivation rec {
+  name = simpleName;
+
+  src = if pkgs.stdenv.isDarwin
+  then pkgs.fetchzip {
+    url = release.${"${attrName}-darwin"}.url;
+    sha256 = release.${"${attrName}-darwin"}.hash;
+  }
+  else pkgs.fetchzip {
+    url = release.${"${attrName}-linux"}.url;
+    sha256 = release.${"${attrName}-linux"}.hash;
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    binPath="$out/bin/${binName}"
+    install -D -m555 -T ${binName} "$binPath"
+
+    mkdir -p $out/etc/bash_completion.d/
+    "$binPath" --bash-completion-script "$binPath" > "$out/etc/bash_completion.d/${completionName}-completion.bash"
+  '';
+}

--- a/build.nix
+++ b/build.nix
@@ -1,6 +1,6 @@
 { pkgs, release }:
 
-{ simpleName, binName, attrName, completionName ? binName }:
+{ simpleName, binName, attrName }:
 
 let
   release = import ./release.nix;
@@ -25,6 +25,6 @@ pkgs.stdenv.mkDerivation rec {
     install -D -m555 -T ${binName} "$binPath"
 
     mkdir -p $out/etc/bash_completion.d/
-    "$binPath" --bash-completion-script "$binPath" > "$out/etc/bash_completion.d/${completionName}-completion.bash"
+    "$binPath" --bash-completion-script "$binPath" > "$out/etc/bash_completion.d/${binName}-completion.bash"
   '';
 }

--- a/build.nix
+++ b/build.nix
@@ -19,12 +19,18 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = release.${"${attrName}-linux"}.hash;
   };
 
+  nativeBuildInputs = [ pkgs.installShellFiles ];
+
   installPhase = ''
     mkdir -p $out/bin
     binPath="$out/bin/${binName}"
     install -D -m555 -T ${binName} "$binPath"
 
-    mkdir -p $out/etc/bash_completion.d/
-    "$binPath" --bash-completion-script "$binPath" > "$out/etc/bash_completion.d/${binName}-completion.bash"
+    "$binPath" --bash-completion-script "$binPath" > "${binName}.bash"
+    installShellCompletion --bash "${binName}.bash"
+    "$binPath" --zsh-completion-script "$binPath" > "${binName}.zsh"
+    installShellCompletion --zsh "${binName}.zsh"
+    "$binPath" --fish-completion-script "$binPath" > "${binName}.fish"
+    installShellCompletion --fish "${binName}.fish"
   '';
 }

--- a/dhall-bash-simple.nix
+++ b/dhall-bash-simple.nix
@@ -1,28 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-bash-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-bash-darwin.url;
-    sha256 = release.dhall-bash-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-bash-linux.url;
-    sha256 = release.dhall-bash-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL_TO_BASH=$out/bin/dhall-to-bash
-    install -D -m555 -T dhall-to-bash $DHALL_TO_BASH
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL_TO_BASH --bash-completion-script $DHALL_TO_BASH > $out/etc/bash_completion.d/dhall-to-bash-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-bash-simple";
+  binName = "dhall-to-bash";
+  attrName = "dhall-bash";
 }

--- a/dhall-json-simple.nix
+++ b/dhall-json-simple.nix
@@ -17,6 +17,8 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = release.dhall-json-linux.hash;
   };
 
+  nativeBuildInputs = [ pkgs.installShellFiles ];
+
   installPhase = ''
     mkdir -p $out/bin
     DHALL_TO_JSON=$out/bin/dhall-to-json
@@ -26,9 +28,23 @@ pkgs.stdenv.mkDerivation rec {
     install -D -m555 -T dhall-to-yaml $DHALL_TO_YAML
     install -D -m555 -T json-to-dhall $JSON_TO_DHALL
 
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL_TO_JSON --bash-completion-script $DHALL_TO_JSON > $out/etc/bash_completion.d/dhall-to-json-completion.bash
-    $DHALL_TO_YAML --bash-completion-script $DHALL_TO_YAML > $out/etc/bash_completion.d/dhall-to-yaml-completion.bash
-    $JSON_TO_DHALL --bash-completion-script $JSON_TO_DHALL > $out/etc/bash_completion.d/json-to-dhall-completion.bash
+    "$DHALL_TO_JSON" --bash-completion-script "$DHALL_TO_JSON" > "dhall-to-json.bash"
+    "$DHALL_TO_YAML" --bash-completion-script "$DHALL_TO_YAML" > "dhall-to-yaml.bash"
+    "$JSON_TO_DHALL" --bash-completion-script "$JSON_TO_DHALL" > "json-to-dhall.bash"
+    installShellCompletion --bash "dhall-to-json.bash"
+    installShellCompletion --bash "dhall-to-yaml.bash"
+    installShellCompletion --bash "json-to-dhall.bash"
+    "$DHALL_TO_JSON" --zsh-completion-script "$DHALL_TO_JSON" > "dhall-to-json.zsh"
+    "$DHALL_TO_YAML" --zsh-completion-script "$DHALL_TO_YAML" > "dhall-to-yaml.zsh"
+    "$JSON_TO_DHALL" --zsh-completion-script "$JSON_TO_DHALL" > "json-to-dhall.zsh"
+    installShellCompletion --zsh "dhall-to-json.zsh"
+    installShellCompletion --zsh "dhall-to-yaml.zsh"
+    installShellCompletion --zsh "json-to-dhall.zsh"
+    "$DHALL_TO_JSON" --fish-completion-script "$DHALL_TO_JSON" > "dhall-to-json.fish"
+    "$DHALL_TO_YAML" --fish-completion-script "$DHALL_TO_YAML" > "dhall-to-yaml.fish"
+    "$JSON_TO_DHALL" --fish-completion-script "$JSON_TO_DHALL" > "json-to-dhall.fish"
+    installShellCompletion --fish "dhall-to-json.fish"
+    installShellCompletion --fish "dhall-to-yaml.fish"
+    installShellCompletion --fish "json-to-dhall.fish"
   '';
 }

--- a/dhall-lsp-simple.nix
+++ b/dhall-lsp-simple.nix
@@ -1,28 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-lsp-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-lsp-server-darwin.url;
-    sha256 = release.dhall-lsp-server-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-lsp-server-linux.url;
-    sha256 = release.dhall-lsp-server-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL_LSP=$out/bin/dhall-lsp-server
-    install -D -m555 -T dhall-lsp-server $DHALL_LSP
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL_LSP --bash-completion-script $DHALL_LSP > $out/etc/bash_completion.d/dhall-lsp-server-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-lsp-simple";
+  binName = "dhall-lsp-server";
+  attrName = "dhall-lsp-server";
 }

--- a/dhall-nix-simple.nix
+++ b/dhall-nix-simple.nix
@@ -1,28 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-nix-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-nix-darwin.url;
-    sha256 = release.dhall-nix-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-nix-linux.url;
-    sha256 = release.dhall-nix-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL_TO_NIX=$out/bin/dhall-to-nix
-    install -D -m555 -T dhall-to-nix $DHALL_TO_NIX
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL_TO_NIX --bash-completion-script $DHALL_TO_NIX > $out/etc/bash_completion.d/dhall-to-nix-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-nix-simple";
+  binName = "dhall-to-nix";
+  attrName = "dhall-nix";
 }

--- a/dhall-simple.nix
+++ b/dhall-simple.nix
@@ -1,28 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-darwin.url;
-    sha256 = release.dhall-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-linux.url;
-    sha256 = release.dhall-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL=$out/bin/dhall
-    install -D -m555 -T dhall $DHALL
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL --bash-completion-script $DHALL > $out/etc/bash_completion.d/dhall-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-simple";
+  binName = "dhall";
+  attrName = "dhall";
 }

--- a/dhall-yaml-simple.nix
+++ b/dhall-yaml-simple.nix
@@ -4,5 +4,4 @@ import ./build.nix { inherit pkgs; release = import ./release.nix; } {
   simpleName = "dhall-yaml-simple";
   binName = "dhall-to-yaml-ng";
   attrName = "dhall-yaml";
-  completionName = "dhall-to-yaml";
 }

--- a/dhall-yaml-simple.nix
+++ b/dhall-yaml-simple.nix
@@ -1,28 +1,8 @@
 { pkgs ? import <nixpkgs> {} }:
 
-let
-  release = import ./release.nix;
-in
-
-pkgs.stdenv.mkDerivation rec {
-  name = "dhall-yaml-simple";
-
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchzip {
-    url = release.dhall-yaml-darwin.url;
-    sha256 = release.dhall-yaml-darwin.hash;
-  }
-  else pkgs.fetchzip {
-    url = release.dhall-yaml-linux.url;
-    sha256 = release.dhall-yaml-linux.hash;
-  };
-
-  installPhase = ''
-    mkdir -p $out/bin
-    DHALL_TO_YAML=$out/bin/dhall-to-yaml-ng
-    install -D -m555 -T dhall-to-yaml-ng $DHALL_TO_YAML
-
-    mkdir -p $out/etc/bash_completion.d/
-    $DHALL_TO_YAML --bash-completion-script $DHALL_TO_YAML > $out/etc/bash_completion.d/dhall-to-yaml-completion.bash
-  '';
+import ./build.nix { inherit pkgs; release = import ./release.nix; } {
+  simpleName = "dhall-yaml-simple";
+  binName = "dhall-to-yaml-ng";
+  attrName = "dhall-yaml";
+  completionName = "dhall-to-yaml";
 }


### PR DESCRIPTION
Uses the new optparse-applicative support for fish and zsh,
and the nixpkgs `installShellCompletion` hook to automatically put the
completions in the right directories.

Based on https://github.com/justinwoo/easy-dhall-nix/pull/29 otherwise I would go crazy.